### PR TITLE
fix namespace errors

### DIFF
--- a/_sources/dcat-records/context.jsonld
+++ b/_sources/dcat-records/context.jsonld
@@ -109,8 +109,8 @@
         "@id": "dcat:contactPoint",
         "@type": "@id"
       },
-      "license": "dcat:license",
-      "rights": "dcat:rights",
+      "license": "dct:license",
+      "accessrights": "dct:accessRights",
       "linkTemplates": "rec:hasLinkTemplate",
       "variables": {
         "@container": "@id",

--- a/_sources/dcat-records/context.jsonld
+++ b/_sources/dcat-records/context.jsonld
@@ -92,7 +92,7 @@
             "@id": "rec:concept",
             "@context": {
               "id": { "@type":  "xsd:string" , "@id": "rec:conceptID" },
-              "url": { "@type":  "@id" , "@id": "dct:theme" }
+              "url": { "@type":  "@id" , "@id": "dcat:theme" }
             }
           },
           "scheme": "rec:scheme"


### PR DESCRIPTION
I noticed the json-ld context had a dcat:license mapping instead of a dcterms:license 
(and a dcat:rights instead of dcterms:accessRights, although that one is not used in the example...)

I get an error downstream with validation because the semantic uplift uses the dcat:license in favour of the dct:license I have mapped in my json-ld context for dcat-ap-nl.